### PR TITLE
Update GitHub Actions workflow to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Cache nuget package
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -38,14 +38,14 @@ jobs:
     # if: "startsWith(github.event.head_commit.message, 'release:')"
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Cache nuget package
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}


### PR DESCRIPTION
Fixes #83

Update GitHub Actions workflow file `.github/workflows/ci.yml` to use the latest versions of actions.

* Update `actions/checkout` to `v3`.
* Update `actions/setup-dotnet` to `v3`.
* Update `actions/cache` to `v3`.
* Update `dotnet-version` to `8.0.x`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kit086/kit.blog/issues/83?shareId=59db87a3-0ffd-4a12-80ef-6da1bc484126).